### PR TITLE
Updates to build. gradle file

### DIFF
--- a/enigma/build.gradle
+++ b/enigma/build.gradle
@@ -1,0 +1,51 @@
+apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion 29
+    ndkVersion ""
+    defaultConfig {
+        applicationId "enigma.game"
+        minSdkVersion 19
+        targetSdkVersion 29
+        versionCode 1
+        versionName "1.0"
+        externalNativeBuild {
+            ndkBuild {
+                arguments "APP_PLATFORM=android-19"
+                abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+            }
+        }
+    }
+    
+    applicationVariants.all { variant ->
+        variant.outputs.all {
+            outputFileName = "$System.env.BASENAME"
+        }
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+    
+    sourceSets.main {
+        jniLibs.srcDir 'libs'
+    }
+    
+    externalNativeBuild {
+        ndkBuild {
+            buildStagingDirectory "$System.env.WORKDIR/ndk-build"
+            path './Android.mk'
+        }
+    }
+       
+    lintOptions {
+        abortOnError false
+    }
+}
+
+dependencies {
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+}

--- a/enigma/build.gradle
+++ b/enigma/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion "29"
-    ndkVersion "23"
+    android.ndkVersion "23.0.7599858"
     defaultConfig {
         applicationId "enigma.game"
         minSdkVersion 19

--- a/enigma/build.gradle
+++ b/enigma/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    ndkVersion ""
+    compileSdkVersion "29"
+    ndkVersion "23"
     defaultConfig {
         applicationId "enigma.game"
         minSdkVersion 19

--- a/enigma/local.properties
+++ b/enigma/local.properties
@@ -1,0 +1,1 @@
+sdk.dir = "%HOME%/Android/Sdk/"


### PR DESCRIPTION
changed the SDK version and NDK version variables in build.gradle file to that specified in the ci. This eliminates errors about the compilesdkVersion not being specified.